### PR TITLE
Fix exception during order with split vouchers

### DIFF
--- a/custom/plugins/resChannable/Components/Webhook/ResChannableWebhook.php
+++ b/custom/plugins/resChannable/Components/Webhook/ResChannableWebhook.php
@@ -142,6 +142,9 @@ class ResChannableWebhook
         $config = $this->_getPluginConfig($shop);
 
         $detail = $this->getDetailRepository()->findOneBy(array('number' => $number));
+        if ( !$detail instanceof \Shopware\Models\Article\Detail )
+            return;
+        
         /** @var \Shopware\Models\Article\Article $article */
         $article = $detail->getArticle();
         $detailId = $detail->getId();


### PR DESCRIPTION
Let the situation be as follows: Your shop has enabled proportional tax calculation. You have a voucher that is restricted to a set of products. A customer has a cart with two products and said voucher. One of the products matches the voucher restriction and the other product does not. The products have different tax rates.

The voucher now is split into two different vouchers; one for each tax rate. The voucher with the tax rate of the matching product has a value below zero. The voucher with a tax rate of the non-matching product has a value of exactly zero, as it does not reduce the value of any line items in the cart.

Shopware would normally not notify the event `product_stock_was_changed` for line items that have a value below zero. See https://github.com/shopware/shopware/blob/406925fbb6a8e98beb94e71ceca1fd473a6edc31/engine/Shopware/Core/sOrder.php#L765 for reference. So since vouchers typically have a value below zero, this event is not normally notified for vouchers. But in this specific case, we have a voucher in the cart that has a value of exactly zero, so this event does get notified.

This in turn triggers the event subscriber of this plugin which tried to update stock changes in real time in Channable. While doing this, the webhook component reads the product data of the line item that triggered the event. Because a voucher is not a real product, the entity manager cannot find a variant entry and instead returns null. Subsequently the call to `$article = $detail->getArticle();` throws a fatal error that is not caught anywhere in the code. Because this interrupts the order finalization, the customer now is presented a 500 error page and the order data in the database is disrupted at best and completely missing at worst. At this point the customer potentially has already paid for the order that is not almost irrecoverably broken.